### PR TITLE
Token Block Logic Updates

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -85,19 +85,15 @@ export default {
   methods: {
     ...mapMutations(["loadClasses", "loadAnnotations", "setInputSentences", "clearAllAnnotations", "resetIndex", "setCurrentPage"]),
     switchToPage(page) {
-      //console.log("Changing current page to", page)
       this.setCurrentPage(page);
-      //console.log("Current page is now", this.currentPage)
     },
     onDragEnter() {
-      //console.log("Here");
       this.overlayActive = true;
     },
     onDragLeave() {
       this.overlayActive = false;
     },
     onDrop(event) {
-      //console.log(event);
       this.overlayActive = false;
       this.pendingFileDrop = event.dataTransfer.files[0]
       if (this.currentPage == "start")  this.processFileDrop();

--- a/src/components/blocks/TokenBlock.vue
+++ b/src/components/blocks/TokenBlock.vue
@@ -1,44 +1,20 @@
 <template>
-  <mark :class="['bg-' + backgroundColor, {'shadow-unreviewed': !this.userHasToggled, 'bg-red': !token.humanOpinion}]">
-    <Token
-      v-for="t in token.tokens"
-      :key="t.start"
-      :token="t"
-    />
+  <mark :class="['bg-' + backgroundColor, { 'shadow-unreviewed': !this.userHasToggled, 'bg-red': !token.humanOpinion }]">
+    <Token v-for="t in token.tokens" :key="t.start" :token="t" />
     <span class="tag">
       <!-- Toggle status cycle button -->
-      <i v-if="this.currentPage==='review'" :class="symbolClass" @click="toggleSymbol"></i>
+      <i v-if="this.currentPage === 'review'" :class="symbolClass" @click="toggleSymbol"></i>
       {{ token.label }}
       <!-- Replace label button (double arrows) -->
-      <q-btn
-        icon="fa fa-exchange-alt"
-        round
-        flat
-        size="xs"
-        text-color="grey-7"
+      <q-btn icon="fa fa-exchange-alt" round flat size="xs" text-color="grey-7"
         title="Change label to currently selected label"
-        @click="recordActionAndEmit('replace-block-label', token.start)"
-      />
+        @click="changeClass" />
       <!-- Delete label button (X) -->
-      <q-btn
-        icon="fa fa-times-circle"
-        round
-        flat
-        size="xs"
-        text-color="grey-7"
-        title="Delete annotation"
-        @click.stop="recordActionAndEmit('remove-block', token.start)" 
-      />
-      <q-btn
-        v-if="this.currentPage==='review'"
-        :icon="reviewedIconClass"
-        round
-        flat
-        size="xs"
-        text-color="grey-9"
+      <q-btn icon="fa fa-times-circle" round flat size="xs" text-color="grey-7" title="Delete annotation"
+        @click.stop="recordActionAndEmit('remove-block', token.start)" />
+      <q-btn v-if="this.currentPage === 'review'" :icon="reviewedIconClass" round flat size="xs" text-color="grey-9"
         title="Dark indicates that you have reviewed this annotation, light means you have not."
-        @click.stop="toggleReviewed"
-      />
+        @click.stop="toggleReviewed" />
     </span>
   </mark>
 </template>
@@ -75,11 +51,13 @@ export default {
         case 0: return "fas fa-hourglass-start fa-lg"; // Candidate - Hourglass implies waiting or potential
         case 1: return "fas fa-thumbs-up fa-lg"; //accepted
         case 2: return "fas fa-skull-crossbones fa-lg"; //rejected
+        case 3: return "fas fa-history fa-lg"; // Suggested
         default: return "fas fa-question-circle fa-lg";
       }
     },
     reviewedIconClass() {
-      return this.userHasToggled ? 'fas fa-toggle-on' : 'fas fa-toggle-off';    },
+      return this.userHasToggled ? 'fas fa-toggle-on' : 'fas fa-toggle-off';
+    },
   },
   methods: {
     toggleSymbol() {
@@ -111,30 +89,54 @@ export default {
       this.recordAction(action, this.token);
       this.$emit(action, payload);
     },
+    changeClass() {
+      if (this.currentPage === 'review') {
+          this.$emit('update-symbol-state', {
+            tokenStart: this.token.start,
+            newSymbolState: 3, // state for suggested
+            oldSymbolState: this.isSymbolActive
+          });
+      }
+      this.recordActionAndEmit('replace-block-label', this.token.start)
+    },
   },
 };
 </script>
 
 <style lang="scss">
-mark {
-  padding: 0.7rem; /* Increased from 0.5rem */
-  position: relative;
-  background-color: burlywood;
-  border: 2px solid $grey-7; /* Thicker border for emphasis */
-  border-radius: 0.5rem; /* Larger border-radius */
-}
-.tag {
-  background-color: whitesmoke;
-  padding: 6px 0 8px 16px; /* Increased padding for larger tag area */
-  border: 2px solid grey; /* Thicker border */
-  border-radius: 0.5rem; /* Larger border-radius */
-  font-size: small; /* Increased font size for better visibility */
-}
-.shadow-unreviewed {
-  box-shadow: 0 0 2px 2px goldenrod; /* Larger and more pronounced shadow */
-}
-.bg-red {
-  box-shadow: 0 0 2px 2px red; /* Larger and more pronounced shadow */
-}
-</style>
+  i {
+    cursor: pointer;
+  }
+  mark {
+    padding: 0.7rem;
+    /* Increased from 0.5rem */
+    position: relative;
+    background-color: burlywood;
+    border: 2px solid $grey-7;
+    /* Thicker border for emphasis */
+    border-radius: 0.5rem;
+    /* Larger border-radius */
+  }
 
+  .tag {
+    background-color: whitesmoke;
+    padding: 6px 0 8px 16px;
+    /* Increased padding for larger tag area */
+    border: 2px solid grey;
+    /* Thicker border */
+    border-radius: 0.5rem;
+    /* Larger border-radius */
+    font-size: small;
+    /* Increased font size for better visibility */
+  }
+
+  .shadow-unreviewed {
+    box-shadow: 0 0 2px 2px goldenrod;
+    /* Larger and more pronounced shadow */
+  }
+
+  .bg-red {
+    box-shadow: 0 0 2px 2px red;
+    /* Larger and more pronounced shadow */
+  }
+</style>

--- a/src/components/blocks/TokenBlock.vue
+++ b/src/components/blocks/TokenBlock.vue
@@ -1,5 +1,5 @@
 <template>
-  <mark :class="['bg-' + backgroundColor, {'shadow-unreviewed': !userHasToggled, 'bg-red': !token.humanOpinion}]">
+  <mark :class="['bg-' + backgroundColor, {'shadow-unreviewed': !this.userHasToggled, 'bg-red': !token.humanOpinion}]">
     <Token
       v-for="t in token.tokens"
       :key="t.start"
@@ -94,16 +94,15 @@ export default {
       });
     },
     toggleReviewed() {
-      this.recordAction('review-state', this.isReviewed);
-      this.isReviewed = !this.isReviewed;
-      this.userHasToggled = true;  // Set userHasToggled to true when review state is toggled
+      this.userHasToggled = !this.userHasToggled;
+      this.$emit('user-toggle', this.token.start);
     },
     recordAction(actionType, previousState) {
       const action = {
         type: actionType,
         tokenStart: this.token.start,
         previousState: previousState,
-        newState: this[actionType === 'symbol-state' ? 'isSymbolActive' : 'isReviewed'],
+        newState: this[actionType === 'symbol-state' ? 'isSymbolActive' : 'userHasToggled'],
         timestamp: Date.now()
       };
       this.$emit('record-undo', action);

--- a/src/components/menubar/ExportAnnotations.vue
+++ b/src/components/menubar/ExportAnnotations.vue
@@ -18,8 +18,6 @@ export default {
       const annotator = prompt('Please enter your name for the annotations export:');
       if (annotator) {
         this.generateJSONExport(annotator);
-      } else {
-        ////console.log('Export cancelled or name not provided.');
       }
     },
 
@@ -43,18 +41,8 @@ export default {
                 annotator,
                 entity.label, // The class or label from the entity
               ];
-              // New annotation in Review mode (missing initial Candidate status)
-              if (history.length == 0 && entity.status == "Accepted") {
-                history.push([
-                  "Candidate",
-                  this.formatDate(new Date()),
-                  annotator,
-                  entity.label, // The class or label from the entity
-                ])
-                history.push(newHistoryEntry); // add to file history
-                // 
-              } else if (entity.userHasToggled && history[history.length-1][2] != annotator) history.push([history[history.length-1][0],this.formatDate(new Date()),annotator,history[history.length-1][3]]) //  Current reviewer "concurs" with previous reviewer and is not the same as previous reviewer
-                else if ((entity.status == "Candidate" && history.length == 0))  history.push(newHistoryEntry); // New annotation in Annotate mode
+              if (entity.userHasToggled && history[history.length-1][2] != annotator) history.push([history[history.length-1][0],this.formatDate(new Date()),annotator,history[history.length-1][3]]) //  Current reviewer "concurs" with previous reviewer and is not the same as previous reviewer
+                else if ((entity.status == "Candidate" || entity.status == "Suggested")&& history.length == 0)  history.push(newHistoryEntry); // New annotation in Annotate or Review mode
                 else if (history[history.length-1][0] != entity.status) history.push(newHistoryEntry); // Status change from previous entry in history
 
               return [
@@ -70,7 +58,6 @@ export default {
       const jsonStr = JSON.stringify(output, null, 2); // Pretty print JSON
       try {
         await exportFile(jsonStr, `${annotator}-annotations.json`);
-        ////console.log("Export successful");
       } catch (error) {
         console.error("Export failed:", error);
       }

--- a/src/components/menubar/ExportAnnotations.vue
+++ b/src/components/menubar/ExportAnnotations.vue
@@ -43,7 +43,7 @@ export default {
                 annotator,
                 entity.label, // The class or label from the entity
               ];
-              // Fixes duplicate entries in history (only add if no history OR state changes)
+              // New annotation in Review mode (missing initial Candidate status)
               if (history.length == 0 && entity.status == "Accepted") {
                 history.push([
                   "Candidate",
@@ -52,9 +52,10 @@ export default {
                   entity.label, // The class or label from the entity
                 ])
                 history.push(newHistoryEntry); // add to file history
-              } else if ((entity.status == "Candidate" && history.length == 0) || (history[history.length-1][0] != entity.status))  {
-                history.push(newHistoryEntry); // add to file history
-              }
+                // 
+              } else if (entity.userHasToggled && history[history.length-1][2] != annotator) history.push([history[history.length-1][0],this.formatDate(new Date()),annotator,history[history.length-1][3]]) //  Current reviewer "concurs" with previous reviewer and is not the same as previous reviewer
+                else if ((entity.status == "Candidate" && history.length == 0))  history.push(newHistoryEntry); // New annotation in Annotate mode
+                else if (history[history.length-1][0] != entity.status) history.push(newHistoryEntry); // Status change from previous entry in history
 
               return [
                 entity.start, // start position

--- a/src/components/pages/AnnotationPage.vue
+++ b/src/components/pages/AnnotationPage.vue
@@ -289,7 +289,7 @@ export default {
             break;
           case 'genericUndo':
             this.tm.removeBlock(details.tokenStart);
-            this.tm.addNewBlock(details.oldBlock.start, details.oldBlock.end, this.classes.find(c => c.name == details.oldBlock.label), details.oldBlock.humanOpinion, details.oldBlock.initiallyNLP, details.oldBlock.isLoaded, details.oldBlock.name, details.oldBlock.status, details.oldBlock.annotationHistory, details.oldBlock.userHasToggled, details.oldBlock.isSymbolActive);
+            this.tm.addNewBlock(details.oldBlock.start, details.oldBlock.end, this.classes.find(c => c.name == details.oldBlock.label), details.oldBlock.humanOpinion, details.oldBlock.initiallyNLP, details.oldBlock.isLoaded, details.oldBlock.name, details.oldBlock.status, details.oldBlock.annotationHistory, details.oldBlock.isSymbolActive);
             this.save();
             break;
         }

--- a/src/components/pages/ReviewPage.vue
+++ b/src/components/pages/ReviewPage.vue
@@ -7,7 +7,7 @@
         :token="t" :class="[t.userHasToggled ? 'user-active' : 'user-inactive']" :isSymbolActive="t.isSymbolActive"
         :backgroundColor="t.backgroundColor" :humanOpinion="t.humanOpinion"
         @update-symbol-state="handleSymbolUpdate(t.start, $event.newSymbolState, $event.oldSymbolState)"
-        @remove-block="onRemoveBlock" @replace-block-label="onReplaceBlockLabel" />
+        @remove-block="onRemoveBlock" @replace-block-label="onReplaceBlockLabel" @user-toggle="handleUserToggle"/>
     </div>
     <div class="q-pa-md" style="border-top: 1px solid #ccc">
       <q-btn class="q-mx-sm" color="primary" outline title="Undo" @click="undo" label="Undo" />
@@ -138,7 +138,6 @@ export default {
           timestamp: Date.now()
         }
       });
-      console.log(this.undoStack)
 
       const token = this.tm.getTokenByStart(tokenStart);
       if (!token) {
@@ -152,6 +151,23 @@ export default {
       token.status = cases[newSymbolState];
 
 
+      this.save()
+    },
+    /**
+     * Handles user toggle state by saving and adding to undo stack
+     *  @param {Number} blockStart - The start position of the block to remove
+     */
+    handleUserToggle(tokenStart) {
+      var block = this.tm.getBlockByStart(tokenStart);
+      this.recordAction({
+        type: 'genericUndo',
+        details: {
+          tokenStart: block.start,
+          oldBlock: block,
+          timestamp: Date.now()
+        }
+      });
+      block.userHasToggled = !block.userHasToggled;
       this.save()
     },
     /**
@@ -333,12 +349,12 @@ export default {
             break;
           case 'symbolChange':
             this.tm.removeBlock(details.tokenStart);
-            this.tm.addNewBlock(details.oldBlock.start, details.oldBlock.end, this.classes.find(c => c.name == details.oldBlock.label), details.oldBlock.humanOpinion, details.oldBlock.initiallyNLP, details.oldBlock.isLoaded, details.oldBlock.name, ["Candidate","Accepted","Rejected"][details.oldSymbolState], details.oldBlock.annotationHistory, details.oldBlock.userHasToggled, details.oldSymbolState);
+            this.tm.addNewBlock(details.oldBlock.start, details.oldBlock.end, this.classes.find(c => c.name == details.oldBlock.label), details.oldBlock.humanOpinion, details.oldBlock.initiallyNLP, details.oldBlock.isLoaded, details.oldBlock.name, ["Candidate","Accepted","Rejected"][details.oldSymbolState], details.oldBlock.annotationHistory, details.oldSymbolState);
             this.save();
             break;
           case 'genericUndo':
             this.tm.removeBlock(details.tokenStart);
-            this.tm.addNewBlock(details.oldBlock.start, details.oldBlock.end, this.classes.find(c => c.name == details.oldBlock.label), details.oldBlock.humanOpinion, details.oldBlock.initiallyNLP, details.oldBlock.isLoaded, details.oldBlock.name, details.oldBlock.status, details.oldBlock.annotationHistory, details.oldBlock.userHasToggled, details.oldBlock.isSymbolActive);
+            this.tm.addNewBlock(details.oldBlock.start, details.oldBlock.end, this.classes.find(c => c.name == details.oldBlock.label), details.oldBlock.humanOpinion, details.oldBlock.initiallyNLP, details.oldBlock.isLoaded, details.oldBlock.name, details.oldBlock.status, details.oldBlock.annotationHistory, details.oldBlock.isSymbolActive);
             this.save();
             break;
         }

--- a/src/components/pages/ReviewPage.vue
+++ b/src/components/pages/ReviewPage.vue
@@ -17,8 +17,7 @@
         @click="resetBlocks" label="Reset" />
       <q-btn class="q-mx-sm" :color="$q.dark.isActive ? 'grey-3' : 'grey-9'" outline
         title="Go back one sentence/paragraph" @click="backOneSentence" :disabled="currentIndex == 0" label="Back" />
-      <q-btn class="q-mx-sm" :color="$q.dark.isActive ? 'grey-3' : 'grey-9'" outline
-        title="Go forward one sentence/paragraph" @click="skipCurrentSentence" label="Next" />
+      <q-btn class="q-mx-sm" :color="$q.dark.isActive ? 'grey-3' : 'grey-9'" outline title="Go forward one sentence/paragraph" @click="skipCurrentSentence" label="Next" />
     </div>
   </div>
 </template>
@@ -38,7 +37,6 @@ export default {
       currentSentence: {},
       redone: "",
       tokenizer: new TreebankTokenizer(),
-      addedTokensStack: [],
       undoStack: [],
     };
   },
@@ -116,7 +114,6 @@ export default {
      * @param {Object} action - The action to record
      */
     recordAction(action) {
-      ////console.log("Recording action:", action); // This will log the action being recorded
       this.undoStack.push(action);
       // Sort the undo stack by the timestamp to ensure the latest action is on top
       this.undoStack.sort((a, b) => b.timestamp - a.timestamp);
@@ -147,10 +144,8 @@ export default {
 
       // Update the token's state and toggled status
       this.tm.updateSymbolState(tokenStart, newSymbolState);
-      const cases = ["Candidate", "Accepted", "Rejected"];
+      const cases = ["Candidate", "Accepted", "Rejected", "Suggested"];
       token.status = cases[newSymbolState];
-
-
       this.save()
     },
     /**
@@ -189,11 +184,7 @@ export default {
       // Remove the existing block
       this.tm.removeBlock(blockStart);
       // Create a new block with the same start and end, but with the current tag/label/class
-      if (existingBlock.start !== undefined && existingBlock.end !== undefined) {
-        this.addedTokensStack.push(existingBlock.start);
-        this.tm.addNewBlock(existingBlock.start, existingBlock.end, this.currentClass);
-      }
-      console.log(this.undoStack)
+      this.tm.addNewBlock(existingBlock.start, existingBlock.end, this.currentClass, existingBlock.humanOpinion, existingBlock.initiallyNLP, existingBlock.isLoaded, existingBlock.name, existingBlock.status, existingBlock.annotationHistory, existingBlock.isSymbolActive);
       this.save();
     },
     /**
@@ -241,7 +232,6 @@ export default {
         start = parseInt(rangeStart.startContainer.parentElement.id.replace("t", ""));
         let offsetEnd = parseInt(rangeEnd.endContainer.parentElement.id.replace("t", ""));
         end = offsetEnd + rangeEnd.endOffset;
-        console.log(start)
         if (!isNaN(start) && !isNaN(end)) {
           if (!this.classes.length && selection.anchorNode) {
             alert(
@@ -250,9 +240,7 @@ export default {
             selection.empty();
             return;
           }
-          ////console.log("adding manual block ", start, end, this.currentClass);
-          this.tm.addNewBlock(start, end, this.currentClass, true, false, false, "name", "candidate", null, true);
-          this.addedTokensStack.push(start);
+          this.tm.addNewBlock(start, end, this.currentClass, true, false, false, "name", "Suggested", null, 3);
           this.recordAction({
             type: 'addBlock',
             details: {
@@ -265,11 +253,9 @@ export default {
           selection.empty();
           this.save();
         } else {
-          console.log("selected text were not tokens");
           selection.empty();
         }
       } catch {
-        ////console.log("selected text were not tokens");
         return;
       }  
     },
@@ -339,9 +325,15 @@ export default {
      */
     undo() {
       if (this.undoStack.length > 0) {
-        console.log(this.undoStack)
         const lastAction = this.undoStack.pop();
         var details = lastAction.details;
+        // REALLY GROSS FIX
+        // TODO: FIX EVENTUALLY
+        // Allows one undo for label changes when using Suggested
+        if (this.undoStack.length != 0 && this.undoStack[this.undoStack.length - 1].type == 'symbolChange' && this.undoStack[this.undoStack.length - 1].details.oldBlock.isSymbolActive == 3) {
+          details.oldBlock.isSymbolActive = this.undoStack[this.undoStack.length - 1].details.oldSymbolState
+          this.undoStack.pop()
+        }
         switch (lastAction.type) {
           case 'addBlock':
             this.tm.removeBlock(details.start);
@@ -349,12 +341,12 @@ export default {
             break;
           case 'symbolChange':
             this.tm.removeBlock(details.tokenStart);
-            this.tm.addNewBlock(details.oldBlock.start, details.oldBlock.end, this.classes.find(c => c.name == details.oldBlock.label), details.oldBlock.humanOpinion, details.oldBlock.initiallyNLP, details.oldBlock.isLoaded, details.oldBlock.name, ["Candidate","Accepted","Rejected"][details.oldSymbolState], details.oldBlock.annotationHistory, details.oldSymbolState);
+            this.tm.addNewBlock(details.oldBlock.start, details.oldBlock.end, this.classes.find(c => c.name == details.oldBlock.label), details.oldBlock.humanOpinion, details.oldBlock.initiallyNLP, details.oldBlock.isLoaded, details.oldBlock.name, ["Candidate","Accepted","Rejected","Suggested"][details.oldSymbolState], details.oldBlock.annotationHistory, details.oldSymbolState);
             this.save();
             break;
           case 'genericUndo':
             this.tm.removeBlock(details.tokenStart);
-            this.tm.addNewBlock(details.oldBlock.start, details.oldBlock.end, this.classes.find(c => c.name == details.oldBlock.label), details.oldBlock.humanOpinion, details.oldBlock.initiallyNLP, details.oldBlock.isLoaded, details.oldBlock.name, details.oldBlock.status, details.oldBlock.annotationHistory, details.oldBlock.isSymbolActive);
+            this.tm.addNewBlock(details.oldBlock.start, details.oldBlock.end, this.classes.find(c => c.name == details.oldBlock.label), details.oldBlock.humanOpinion, details.oldBlock.initiallyNLP, details.oldBlock.isLoaded, details.oldBlock.name, ["Candidate","Accepted","Rejected","Suggested"][details.oldBlock.isSymbolActive], details.oldBlock.annotationHistory, details.oldBlock.isSymbolActive);
             this.save();
             break;
         }

--- a/src/components/pages/StartPage.vue
+++ b/src/components/pages/StartPage.vue
@@ -159,7 +159,6 @@ export default {
             this.$emit("text-file-loaded");
           }
           else if (fileType === "json") {
-            ////console.log("Emitting json-file-loaded");
             this.$emit("json-file-loaded");
           }
           else {
@@ -167,7 +166,6 @@ export default {
           }
         });
       } catch (e) {
-        ////console.log("Catch reached")
         this.fileSelectionError();
       }
     },

--- a/src/components/token-manager.js
+++ b/src/components/token-manager.js
@@ -34,7 +34,7 @@ class TokenManager {
         if (!entityClass) {
           entityClass = {"name": entityName};
         }
-        this.addNewBlock(annotation.start, annotation.end, entityClass, annotation.ogNLP, annotation.ogNLP, true, annotation.name, annotation.status, annotation.history, false, annotation.isSymbolActive);
+        this.addNewBlock(annotation.start, annotation.end, entityClass, annotation.ogNLP, annotation.ogNLP, true, annotation.name, annotation.status, annotation.history, annotation.isSymbolActive);
       }
     }
   }
@@ -46,10 +46,10 @@ class TokenManager {
    * @param {Number} start 'start' value of the token forming the start of the token block
    * @param {Number} end 'start' value of the token forming the end of the token block
    * @param {Number} _class the id of the class to highlight
-   * @param {Boolean} isHumanOpinion Seperate nlp vs human made annotation
+   * @param {Boolean} isHumanOpinion Separate nlp vs human made annotation
 
    */
-  addNewBlock(_start, _end, _class, humanOpinion, initiallyNLP = false, isLoaded, name="name", status ="Candidate", annotationHistory, userHasToggled = true,isSymbolActive = 0) {
+  addNewBlock(_start, _end, _class, humanOpinion, initiallyNLP = false, isLoaded, name="name", status ="Candidate", annotationHistory, isSymbolActive = 0) {
     // Directly apply humanOpinion to the block structure
     let selectedTokens = [];
     let newTokens = [];
@@ -102,11 +102,11 @@ class TokenManager {
           backgroundColor: _class.color || null,
           // Set these attributes for all token-blocks, updating existing blocks as needed
           initiallyNLP: updateAttributes ? initiallyNLP : false,
-          userHasToggled: true,
           isSymbolActive: isSymbolActive,
           isLoaded: isLoaded,
           status: status,
           annotationHistory: annotationHistory,
+          userHasToggled: false,
         };
         tokensArray.push(newBlock);
       }
@@ -172,6 +172,7 @@ class TokenManager {
           label: b.label,
           isSymbolActive: b.isSymbolActive,
           ogNLP: b.initiallyNLP,
+          userHasToggled: b.userHasToggled,
         }
         entities.push(historyEntry);
       }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -119,8 +119,6 @@ export const mutations = {
               isSymbolActive: determineSymbolState(latestEntry[0]),
               ogNLP: thisAnnotationHistory[0][2] === "nlp",
             }
-
-            //[b.name, b.start, b.end, b.label, b.initiallyNLP, b.isSymbolActive, b.userHasToggled, b.isLoaded,b.status,b.annotationHistory]
             annotationHistory.push(historyEntry);
 
             ////console.log("Loaded annotation history:", types);

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,9 +4,7 @@ const niceColors = ["red-11", "blue-11", "light-green-11", "deep-orange-11", "pi
 
 export const mutations = {
   setCurrentPage(state, page) {
-    // ////console.log("From index.js, changing currentpage to", page)
     state.currentPage = page;
-    // ////console.log("From index.js, current page is now", state.currentPage)
   },
   addToUndoStack(state, { undoAction, actionDescription }) {
     state.undoStack.push({ undoAction, actionDescription });
@@ -22,7 +20,6 @@ export const mutations = {
     if (state.undoStack.length > 0) {
       const lastAction = state.undoStack.pop();
       lastAction.undoAction();
-      ////console.log(`Undid action: ${lastAction.actionDescription}`);
     } else {
       console.warn("Undo stack is empty.");
     }
@@ -121,7 +118,6 @@ export const mutations = {
             }
             annotationHistory.push(historyEntry);
 
-            ////console.log("Loaded annotation history:", types);
           }
         });
         if (annotationEntities.entities.length) state.annotationHistory[i] = annotationHistory;
@@ -143,7 +139,6 @@ export const mutations = {
 
     // If the class already exists, return
     if (existingClass) {
-      ////console.log('Class already exists, returning.');
       return;
     }
 
@@ -162,7 +157,6 @@ export const mutations = {
       // If this is the first class, set it as the currentClass
       if (state.classes.length === 1) {
         state.currentClass = state.classes[0];
-        ////console.log('Updated currentClass:', state.currentClass);
       }
     }
   },


### PR DESCRIPTION
Fixes #18. New logic is in accordance with the following diagram
![image](https://github.com/user-attachments/assets/e8703261-f4b6-4846-a73a-e1b654e36736)

In summary:
- Adding a new annotation in __Review mode__ will record the annotation as _Suggested_. There will be no history entry for __Candidate__
- Adding a new annotation in __Annotate mode__ will record the annotation as _Candidate_
- Changing the label records as _Suggested_
- Toggling the rightmost toggle will __duplicate the most recent history entry with the current time and annotator name__ unless the __current annotator shares the same name as the previous annotator__