### PR TITLE
Improvements Batch 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "TART",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,9 +9,9 @@
   >
     <div :style="{'pointer-events': overlayActive ? 'none' : 'auto'}">
       <q-layout view="hHh lpR fFf">
-        <menu-bar @text-file-loaded="switchToPage('annotate')" @json-file-loaded="switchToPage('review')"/>
+        <menu-bar/>
         <q-page-container>
-          <start-page v-if="currentPage === 'start'" @text-file-loaded="switchToPage('annotate')" @json-file-loaded="switchToPage('review')"/>
+          <start-page v-if="currentPage === 'start'"/>
           <annotation-page v-if="currentPage === 'annotate'" />
           <review-page v-if="currentPage === 'review'" />
         </q-page-container>
@@ -28,7 +28,6 @@ import StartPage from "./components/pages/StartPage.vue";
 import AnnotationPage from "./components/pages/AnnotationPage.vue";
 import ReviewPage from "./components/pages/ReviewPage.vue";
 import DragNDropOverlay from "./components/etc/DragNDropOverlay.vue";
-import ExitDialog from "./components/dialogs/ExitDialog.vue";
 import { mapState, mapMutations } from "vuex";
 import { useQuasar } from "quasar";
 
@@ -65,48 +64,23 @@ export default {
     StartPage,
     AnnotationPage,
     ReviewPage,
-    DragNDropOverlay,
-    ExitDialog
+    DragNDropOverlay
   },
   computed: {
     ...mapState(["annotations", "classes", "currentPage"]),
   },
   methods: {
-    ...mapMutations(["loadClasses", "loadAnnotations", "setInputSentences", "clearAllAnnotations", "resetIndex", "setCurrentPage"]),
-    switchToPage(page) {
-      this.setCurrentPage(page);
-    },
+    ...mapMutations(["loadClasses", "loadAnnotations", "setInputSentences", "clearAllAnnotations", "resetIndex", "setCurrentPage", "loadFile"]),
     onDragEnter() {
-      this.overlayActive = true;
+      if (this.currentPage == "start") this.overlayActive = true;
     },
     onDragLeave() {
-      this.overlayActive = false;
+      if (this.currentPage == "start") this.overlayActive = false;
     },
     onDrop(event) {
       this.overlayActive = false;
       this.pendingFileDrop = event.dataTransfer.files[0]
-      if (this.currentPage == "start")  this.processFileDrop();
-    },
-    processFileDrop() {
-      let fileType = this.pendingFileDrop.name.split('.').pop();
-      let reader = new FileReader();
-      reader.onload = (event) => {
-        let file = event.target.result;
-        this.setInputSentences(file);
-        this.clearAllAnnotations();
-        this.resetIndex();
-        if (fileType === "txt") {
-          this.switchToPage('annotate');
-        }
-        else if (fileType === "json") {
-          this.switchToPage('review');
-        }
-        else {
-          alert('Please upload either a .txt or a .json file.');
-        }
-      };
-      reader.readAsText(this.pendingFileDrop);
-      this.pendingFileDrop = null;
+      if (this.currentPage == "start")  this.loadFile(this.pendingFileDrop);
     },
   },
 };

--- a/src/components/dialogs/AboutDialog.vue
+++ b/src/components/dialogs/AboutDialog.vue
@@ -7,7 +7,7 @@
           <p><strong>Version: </strong>{{ version }}</p>
           <p>
             <strong>Source: </strong>
-            Adapted from <a href="https://github.com/tecoholic/ner-annotator" target="_blank">NER Annotator</a> into <a href="https://github.com/theSKAILab/TeAM-NER" target="_blank">TART Tool</a>
+            Adapted from <a href="https://github.com/tecoholic/ner-annotator" target="_blank">NER Annotator</a> into <a href="https://github.com/theSKAILab/TART" target="_blank">TART Tool</a>
           </p>
           <p>
             <strong>Author:</strong><br/>

--- a/src/components/etc/ExportAnnotations.vue
+++ b/src/components/etc/ExportAnnotations.vue
@@ -45,15 +45,21 @@ export default {
                 annotator,
                 entity.labelClass.name, // The class or label from the entity
               ];
-              if (entity.reviewed && history[history.length-1][2] != annotator && history[history.length-1][0] == entity.currentState) 
+              if (entity.reviewed && history[history.length-1][2] != annotator && history[history.length-1][0] == entity.currentState && history[history.length-1][3] == entity.labelClass.name) 
               {
-                history.push([history[history.length-1][0],this.formatDate(new Date()),annotator,history[history.length-1][3]]) //  Current reviewer "concurs" with previous reviewer and is not the same as previous reviewer
+                history.push(
+                  [
+                    history[history.length-1][0],
+                    this.formatDate(new Date()),
+                    annotator,
+                    history[history.length-1][3]]
+                ) //  Current reviewer "concurs" with previous reviewer and is not the same as previous reviewer
               }
               else if ((entity.currentState == "Candidate" || entity.currentState == "Suggested") && history.length == 0) 
               {
                 history.push(newHistoryEntry); // New annotation in Annotate or Review mode
               }
-              else if (history[history.length-1][0] != entity.currentState) 
+              else if (history[history.length-1][0] != entity.currentState || history[history.length-1][3] != entity.labelClass.name) 
               {
                 history.push(newHistoryEntry); // Status change from previous entry in history
               }

--- a/src/components/etc/ExportAnnotations.vue
+++ b/src/components/etc/ExportAnnotations.vue
@@ -17,7 +17,7 @@ export default {
           prompt: {
             model: '',
             type: 'text', // optional
-            isValid: val => val.length > 2,
+            isValid: val => val.length > 0,
           },
           cancel: true,
           persistent: true

--- a/src/components/etc/ExportAnnotations.vue
+++ b/src/components/etc/ExportAnnotations.vue
@@ -59,10 +59,10 @@ export default {
               }
 
               return [
+                null, // id field required for knowledge graph, initially null
                 entity.start, // start position
                 entity.end, // end position
                 history.map(h => [h[0], h[1], h[2], h[3]]), // history array
-                null, // id field required for knowledge graph, initially null
               ];
             }): []
           }

--- a/src/components/etc/shared.vue
+++ b/src/components/etc/shared.vue
@@ -136,6 +136,9 @@ export default {
         text: this.currentSentence.text,
         entities: this.tm.exportAsAnnotation(),
       });
+    },
+    beforeLeave() {
+      return "Leaving this page will discard any unsaved changes.";
     }
   },
 }

--- a/src/components/etc/shared.vue
+++ b/src/components/etc/shared.vue
@@ -108,8 +108,17 @@ export default {
       // Determine if the selection will overlap with an existing block and add to undo stack accordingly
       var existingBlocks = this.tm.isOverlapping(start, end);
       if (existingBlocks) {
-        this.addUndoOverlapping({"oldBlocks": existingBlocks, "newBlockStart": start});
-        this.tm.addNewBlock(start, end, this.currentClass, "Suggested", this.currentPage);
+        // Prompt to user to confirm overlapping blocks
+        this.$q.dialog({
+          title: 'Overlapping Annotations',
+          message: 'Your selection overlaps with existing annotations. Continuing will apply your current selection to the existing block. Do you want to proceed?',
+          cancel: true,
+          persistent: true
+        }).onOk(() => {
+          this.addUndoOverlapping({"oldBlocks": existingBlocks, "newBlockStart": start});
+          this.tm.addNewBlock(start, end, this.currentClass, "Suggested", this.currentPage);
+        })
+        
       } else {
         this.tm.addNewBlock(start, end, this.currentClass, this.currentPage == "annotate"? "Candidate": "Suggested", this.currentPage);
         if (this.tm.getBlockByStart(start)) this.addUndoCreate(this.tm.getBlockByStart(start));

--- a/src/components/etc/token-manager.js
+++ b/src/components/etc/token-manager.js
@@ -138,7 +138,6 @@ class TokenManager {
           end: tokens[tokens.length - 1].end,
           tokens: tokens,
           labelClass: _class,
-          classId: _class.id || 0,
           currentState: currentState,
           reviewed: false,
           history: history

--- a/src/components/objects/TokenBlock.vue
+++ b/src/components/objects/TokenBlock.vue
@@ -46,7 +46,7 @@ export default {
   data() {
     return {
       states: {
-        "Candidate": {numeric: 0, icon: "fas fa-ellipsis-h fa-lg"},
+        "Candidate": {numeric: 0, icon: "fas fa-question fa-lg"},
         "Accepted": {numeric: 1, icon: "fas fa-thumbs-up fa-lg"},
         "Rejected": {numeric: 2, icon: "fas fa-thumbs-down fa-lg"},
         "Suggested": {numeric: 3, icon: "fas fa-pen fa-lg"}

--- a/src/components/objects/TokenBlock.vue
+++ b/src/components/objects/TokenBlock.vue
@@ -3,7 +3,10 @@
     <Token v-for="t in token.tokens" :key="t.start" :token="t" />
     <span class="tag">
       <!-- Toggle status cycle button -->
-      <i v-if="this.currentPage === 'review'" :class="this.states[this.currentState].icon" @click="cycleCurrentStatus"></i>
+      <i v-if="this.currentPage === 'review'" :class="this.states[this.currentState].icon" @click="cycleCurrentStatus"
+        :title="[this.currentState + ' - Click to cycle status']"
+        style="cursor: pointer; color: grey-9;"
+      ></i>
       {{ this.labelClass.name }}
       <!-- Replace label button (double arrows) -->
       <q-btn icon="fa fa-exchange-alt" round flat size="xs" text-color="grey-7"

--- a/src/components/pages/AnnotationPage.vue
+++ b/src/components/pages/AnnotationPage.vue
@@ -77,6 +77,7 @@ export default {
       this.tokenizeCurrentSentence()
     }
     document.addEventListener("mouseup", this.selectTokens);
+    window.onbeforeunload = this.beforeLeave;
 
     // Emits
     this.emitter.on('undo', this.undo);

--- a/src/components/pages/ReviewPage.vue
+++ b/src/components/pages/ReviewPage.vue
@@ -94,6 +94,7 @@ export default {
       this.tokenizeCurrentSentence()
     }
     document.addEventListener("mouseup", this.selectTokens);
+    window.onbeforeunload = this.beforeLeave;
 
     // Emits
     this.emitter.on('undo', this.undo);

--- a/src/components/pages/StartPage.vue
+++ b/src/components/pages/StartPage.vue
@@ -1,27 +1,58 @@
 <template>
-  <div class="q-mx-auto q-my-xl column items-center justify-center">
-    <img src="@/assets/umaine-dark.png" alt="UMaine Logo" class="q-mb-sm" width="550px" v-show="$q.dark.isActive"/>
-    <img src="@/assets/umaine.png" alt="UMaine Logo" class="q-mb-sm" width="550px" v-show="!$q.dark.isActive"/>
-    <h6 class="text-center text-h4 q-mb-none q-mt-lg text-bold">Text Annotation Review and Tagging (TART) Tool</h6>
-    <h6 class="text-center text-h6 q-mb-none q-mt-xl text-italic">To Start, Open a File from the 'File' Menu</h6>
-    <div style="position: absolute; bottom: 20px;font-size: 16px;">
-      This research was supported in part by the U.S. Department of Agriculture through a National Institute of Food and Agriculture (NIFA) grant, Award #<a href="https://portal.nifa.usda.gov/web/crisprojectpages/1025810-cellulose-materials-informatics-building-a-knowledge-graph-for-cellulose-materials-discovery-and-research-cellograph.html" target="_blank">2021-67022-34366</a>
-      <div class="q-mt-md row items-center justify-center">
-        <img src="@/assets/skailabicon.png" style="height: 40px;padding-top: 2px;"/>
-        <img src="@/assets/forestserviceicon.png" style="margin-left: 13px; height: 50px;"/>
+  <div class="q-mx-auto q-my-xl">
+    <div class="column items-center justify-center">
+      <h6 class="text-center text-h3 q-mb-none q-mt-lg text-bold">Text Annotation Review and Tagging (TART) Tool</h6>
+      <div style="margin-top: 45px;">
+        <q-file
+          accept=".txt,.json"
+          filled
+          @update:model-value="this.loadFile"
+          label="Open a text or json file to begin"
+          :bg-color="$q.dark.isActive ? 'black-1' : 'light-blue-1'"
+        >
+          <template v-slot:prepend>
+            <q-icon name="fas fa-upload" />
+          </template>
+        </q-file>
+        <p :class="['text-subtitle1 q-my-md', $q.dark.isActive ? 'text-grey-4' : 'text-grey-7']">
+          Hint: You can also drag and drop files into this window!
+        </p>
       </div>
     </div>
+
+    <div class="row" style="position: absolute; bottom: 15px; width: 100%;">
+      <div class="col items-start start-footer justify-end">
+        This tool was designed and developed in the Spatial Knowledge and Artificial Intelligence (SKAI) lab at University of Maine<br/>
+        <div style="height: 45px; padding-top: 5px;" class="row items-center">
+          <div class="col col-md-auto" style="margin-right: 15px;">
+            <img src="@/assets/umaine-dark.png" alt="UMaine Logo" class="q-mb-sm" height="40px" v-show="$q.dark.isActive"/>
+            <img src="@/assets/umaine.png" alt="UMaine Logo" class="q-mb-sm" height="40px" v-show="!$q.dark.isActive"/>
+          </div>
+          <div class="col col-md-auto">
+            <img src="@/assets/skailabicon.png" style="height: 40px;"/>
+          </div>
+        </div>
+      </div>
+      <div class="col start-footer justify-end" style="text-align: center;">
+        <span style="font-weight: bold;">Cite this tool as:</span><br />
+        Author 1, Author 2, Author 3, & Author 4. ({{ new Date().getFullYear() }}). 
+        <span style="font-style: italic;">Text Annotation Review and Tagging (TART)</span> [Computer software].
+      </div>
+      <div class="col items-end start-footer justify-end" style="text-align: right;">
+        This research was supported in part by the U.S. Department of Agriculture through a National Institute of Food and Agriculture (NIFA) grant, Award #<a href="https://portal.nifa.usda.gov/web/crisprojectpages/1025810-cellulose-materials-informatics-building-a-knowledge-graph-for-cellulose-materials-discovery-and-research-cellograph.html" target="_blank">2021-67022-34366</a><br/>
+        <img src="@/assets/forestserviceicon.png" style="height: 50px;margin-top: 15px;"/>
+      </div>
+    </div>
+
   </div>
 </template>
 
 <script>
-
+import { mapMutations } from "vuex";
 export default {
   name: "StartPage",
-  data() {
-    return {
-      textFile: null,
-    };
+  methods: {
+    ...mapMutations(["loadFile"]),
   },
 };
 </script>

--- a/src/components/toolbars/MenuBar.vue
+++ b/src/components/toolbars/MenuBar.vue
@@ -138,7 +138,6 @@ export default {
     };
   },
   created() {
-    console.log(this.$store.state.fileName)
     document.addEventListener('keydown', this.menuKeyBind);
     window.addEventListener("beforeinstallprompt", (e) => {
       this.installablePWA = true;
@@ -184,6 +183,7 @@ export default {
       if (e.key == "m" && e.ctrlKey && isValid) {this.$store.state.currentPage == 'annotate'? this.setCurrentPage('review'): this.setCurrentPage('annotate')}
     },
     reloadWindow() {
+      window.onbeforeunload = null; // Disable the beforeunload event
       window.location.reload();
     }
   },

--- a/src/components/toolbars/MenuBar.vue
+++ b/src/components/toolbars/MenuBar.vue
@@ -80,7 +80,7 @@
             <span class="q-menu-open-button">Help</span>
             <q-menu transition-show="jump-down" transition-hide="jump-up">
               <q-list dense style="min-width: 100px">
-                <q-item clickable v-close-popup href="https://github.com/theSKAILab/TeAM-NER/issues" target="_blank">
+                <q-item clickable v-close-popup href="https://github.com/theSKAILab/TART/issues" target="_blank">
                   Report Issue
                 </q-item>
                 <q-item clickable v-close-popup @click="showAbout = true">

--- a/src/components/toolbars/MenuBar.vue
+++ b/src/components/toolbars/MenuBar.vue
@@ -33,7 +33,7 @@
             </q-menu>
           </div>
           
-          <input @change="(e) => {onFileSelected(e)}" type="file" ref="file" accept=".txt,.json" id="fileupload" style="display: none"/>
+          <input @change="(e) => {this.loadFile(e.target.files[0])}" type="file" ref="file" accept=".txt,.json" id="fileupload" style="display: none"/>
           
           <!-- Edit -->
           <div class="q-ml-md cursor-pointer non-selectable">
@@ -95,7 +95,7 @@
 
         <!-- Program / Mode -->
         <span class="col" style="text-align: center;" v-if="this.$store.state.currentPage != 'start'">
-          <span>{{ this.$store.fileName? this.$store.fileName + " - ": this.$store.currentPage }} </span>
+          <span>{{ titleBar }} </span>
           <span style="font-weight: bold;">{{ this.$store.state.currentPage.charAt(0).toUpperCase() + this.$store.state.currentPage.slice(1) }} Mode</span>
         </span>
 
@@ -138,6 +138,7 @@ export default {
     };
   },
   created() {
+    console.log(this.$store.state.fileName)
     document.addEventListener('keydown', this.menuKeyBind);
     window.addEventListener("beforeinstallprompt", (e) => {
       this.installablePWA = true;
@@ -150,53 +151,14 @@ export default {
     })
   },
   computed: {
-    ...mapState(["annotations", "classes","fileName","lastSavedTimestamp","currentPage"]),
+    ...mapState(["annotations", "classes","fileName","currentPage"]),
+    titleBar() {
+      return this.$store.state.fileName ? this.$store.state.fileName + " - " : "";
+    }
   },
   mixins: [ExportAnnotations],
   methods: {
     ...mapMutations(["setInputSentences", "clearAllAnnotations", "resetIndex", "setCurrentPage","loadFile"]),
-    onFileSelected(file) {
-      // onFileSelected() is called if the user clicks and manually
-      //    selects a file. If they drag and drop, that is handled in
-      //    App.vue. If you modify this function, you may also want to
-      //    modify App#onDrop(), App#processFileDrop(), and
-      //    LoadTextFile#onFileSelected() to match
-      file = file.target.files[0];
-      this.$store.fileName = file.name;
-      let fileType = file.name.split('.').pop();
-      this.$store.lastSavedTimestamp = null;
-      try {
-        let reader = new FileReader();
-        reader.readAsText(file);
-        reader.addEventListener("load", (event) => {
-          this.clearAllAnnotations();
-          this.loadFile(event.target.result);
-
-          if (fileType === "txt") {
-            this.$emit("text-file-loaded");
-          }
-          else if (fileType === "json") {
-            this.$emit("json-file-loaded");
-          }
-          else {
-            this.$q.dialog({
-              title: 'Incompatible File Type',
-              message: 'Please upload either a .txt or a .json file.'
-            })
-            this.setCurrentPage('start')
-          }
-        });
-      } catch (e) {
-        this.$q.notify({
-          icon: "fas fa-exclamation-circle",
-          message: "Invalid file",
-          color: "red-6",
-          position: "top",
-          timeout: 2000,
-          actions: [{label: "Dismiss", color: "white"}],
-        });
-      }
-    },
     toggleDarkMode: function () {
       this.$q.dark.toggle();
     },

--- a/src/components/toolbars/MenuBar.vue
+++ b/src/components/toolbars/MenuBar.vue
@@ -157,7 +157,7 @@ export default {
   },
   mixins: [ExportAnnotations],
   methods: {
-    ...mapMutations(["setInputSentences", "clearAllAnnotations", "resetIndex", "setCurrentPage","loadFile"]),
+    ...mapMutations(["setCurrentPage","loadFile"]),
     toggleDarkMode: function () {
       this.$q.dark.toggle();
     },

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -56,12 +56,12 @@ const mutations = {
         var entity = file.annotations[i][1].entities[j];
         if (entity.length >= 3) {
             
-            const thisAnnotationHistory = entity[2]
+            const thisAnnotationHistory = entity[3]
             const latestEntry = thisAnnotationHistory[thisAnnotationHistory.length - 1];
 
             const historyEntry = {
-              start: entity[0],
-              end: entity[1],
+              start: entity[1],
+              end: entity[2],
               history: thisAnnotationHistory,
               currentState: latestEntry[0],
               name: latestEntry[2],

--- a/src/styles/quasar.scss
+++ b/src/styles/quasar.scss
@@ -107,3 +107,16 @@ body.body--dark {
 span.col > div {
   display: inline-block;
 }
+
+.start-footer {
+  padding: 10px;
+  padding-left: 20px;
+  padding-right: 20px;
+  font-size: 18px;
+  align-self: flex-end;
+}
+
+.start-footer > img {
+  display: inline-block;
+  margin-top: 5px;
+}


### PR DESCRIPTION
Should rectify the issues as stated below: 

1. ~In review mode, if a label is changed (through label changing icon), the label changes on the UI, but in the JSON, it creates a new suggestion entry with the old label.~ Fixed in 02d8937af54d33141cb554c822e875859ae3fe52
2. If a reviewer turns the toggle off after changing the status, the status should revert to its immediate previous value. This functions as a local undo, allowing the reviewer to return within the same session and make a final decision.
3. ~Drag and drop doesn't work.~ Fixed in 0d4760d366635bac9c7030d6c37c68da4d2957d8
4. ~We need to keep the reserved entry for the ID (currently set to null) at the beginning of each list entry. Currently, it is being added at the end.~ Fixed in 6b0603edc54671cdcd05f678f1508714571806bd
5. ~In both modes (when a file is open), if another file is loaded, the file loaded successfully but the filename does not update in the middle of the top bar.~ Fixed in 0d4760d366635bac9c7030d6c37c68da4d2957d8
6. ~The reviewer name currently requires a minimum of three characters. I would probably not restrict it, as some names (particularly Chinese names) consist of only two characters.~ Fixed in 0cce16e441162eec815e097554f35d44d9388c60
7. ~Reloading the browser tab should trigger a pop-up warning as it loses all annotations.~ Fixed in c8f1f2ff0b28af2799488bea838d5998f6724914
8. ~Overlapping annotations should trigger a pop-up warning.~ Fixed in 9158daab8bb79b8b87db215da9d7510e86e3c11a
9. ~A question mark can be used as the candidate icon (instead of the three dots).~ Fixed in 0a78e13cd14362af3bc249739f6d586e5a7f329e

Additionally, the start page styling has been changed, as requested in 82e593f8d874054dca48de81edd362f84174d252

Current version is now **1.4.6**